### PR TITLE
Strip out color codes before checking the answer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,14 +39,14 @@
     <dependency>
         <groupId>net.md-5</groupId>
         <artifactId>bungeecord-api</artifactId>
-        <version>1.7-SNAPSHOT</version>
+        <version>1.8-SNAPSHOT</version>
     	<type>jar</type>
   	</dependency>
   	
   	<dependency>
 	  <groupId>net.cubespace</groupId>
 	  <artifactId>Yamler-Core</artifactId>
-	  <version>2.1.0-SNAPSHOT</version>
+	  <version>2.2.3-SNAPSHOT</version>
 	</dependency>
   </dependencies>
 

--- a/src/au/com/addstar/unscramble/Session.java
+++ b/src/au/com/addstar/unscramble/Session.java
@@ -3,6 +3,7 @@ package au.com.addstar.unscramble;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 import au.com.addstar.unscramble.prizes.Prize;
 
@@ -29,7 +30,9 @@ public class Session implements Runnable
 	private ScheduledTask mTask;
 	
 	private int mChatLines = 0;
-	
+
+	private Pattern STRIP_COLOR_PATTERN;
+
 	public Session(String word, long duration, long hintInterval, Prize prize)
 	{
 		if(word.isEmpty())
@@ -40,7 +43,11 @@ public class Session implements Runnable
 		
 		mHint = word.replaceAll("[^ ]", "*");
 		mHintInterval = hintInterval;
-		
+
+		// From Bungeecord-Chat, specifically net.md_5.bungee.api.ChatColor.stripColor
+		// Updated to change COLOR_CHAR from '§' to '&'
+		STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + String.valueOf('&') + "[0-9A-FK-OR]");
+
 		mPrize = prize;
 		scramble();
 	}
@@ -100,7 +107,7 @@ public class Session implements Runnable
 		if(!isRunning())
 			return;
 
-        guess = net.md_5.bungee.api.ChatColor.stripColor(guess);
+		guess = STRIP_COLOR_PATTERN.matcher(guess).replaceAll("");
 
 		if(mWord.equalsIgnoreCase(guess))
 		{

--- a/src/au/com/addstar/unscramble/Session.java
+++ b/src/au/com/addstar/unscramble/Session.java
@@ -99,7 +99,9 @@ public class Session implements Runnable
 	{
 		if(!isRunning())
 			return;
-		
+
+        guess = net.md_5.bungee.api.ChatColor.stripColor(guess);
+
 		if(mWord.equalsIgnoreCase(guess))
 		{
 			mTask.cancel();

--- a/src/au/com/addstar/unscramble/Session.java
+++ b/src/au/com/addstar/unscramble/Session.java
@@ -46,7 +46,7 @@ public class Session implements Runnable
 
 		// From Bungeecord-Chat, specifically net.md_5.bungee.api.ChatColor.stripColor
 		// Updated to change COLOR_CHAR from '§' to '&'
-		STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + String.valueOf('&') + "[0-9A-FK-OR]");
+		STRIP_COLOR_PATTERN = Pattern.compile("(?i)&[0-9A-FK-OR]");
 
 		mPrize = prize;
 		scramble();

--- a/src/au/com/addstar/unscramble/config/WeightedPrizeSaver.java
+++ b/src/au/com/addstar/unscramble/config/WeightedPrizeSaver.java
@@ -17,14 +17,19 @@ public class WeightedPrizeSaver implements Converter
 	@Override
 	public Object fromConfig( Class<?> clazz, Object obj, ParameterizedType type ) throws Exception
 	{
+		if((obj instanceof WeightedPrize))
+		{
+			return (WeightedPrize)obj;
+		}
+
 		if(!(obj instanceof Map))
 			return null;
-		
+
 		Map<?, ?> map = (Map<?, ?>)obj;
-		
+
 		if(map.isEmpty())
 			return null;
-		
+
 		WeightedPrize prize = new WeightedPrize();
 		Entry<?, ?> entry = map.entrySet().iterator().next();
 		prize.weight = Integer.valueOf((String)entry.getKey());


### PR DESCRIPTION
Requested by in-game user to allow them to use color codes when answering unscramble (ticket 3387).  Compiles successfully, but untested since I don't have a local running instance of Bungee; just Spigot.
